### PR TITLE
add exported HTTPClient to Resolver

### DIFF
--- a/http.go
+++ b/http.go
@@ -11,8 +11,8 @@ import (
 // request as described in RFC 8484, and returns the response's body.
 // Returns an error if there was an issue sending the request or reading the
 // response body.
-func exchangeHTTPS(q []byte, resolver string) (a []byte, err error) {
-	url := fmt.Sprintf("https://%s/dns-query", resolver)
+func (r *Resolver) exchangeHTTPS(q []byte) (a []byte, err error) {
+	url := fmt.Sprintf("https://%s/dns-query", r.Host)
 	body := bytes.NewBuffer(q)
 
 	req, err := http.NewRequest("POST", url, body)
@@ -23,7 +23,11 @@ func exchangeHTTPS(q []byte, resolver string) (a []byte, err error) {
 	req.Header.Add("Accept", "application/dns-message")
 	req.Header.Add("Content-Type", "application/dns-message")
 
-	client := http.Client{}
+	client := r.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
 	resp, err := client.Do(req)
 	if err != nil {
 		return

--- a/resolver.go
+++ b/resolver.go
@@ -1,6 +1,8 @@
 // Package doh implements client operations for DoH (DNS over HTTPS) lookups.
 package doh
 
+import "net/http"
+
 // Resolver handles lookups.
 type Resolver struct {
 	// The host to send DoH requests to.
@@ -8,6 +10,8 @@ type Resolver struct {
 	// The DNS class to lookup with, must be one of IN, CS, CH, HS or ANYCLASS.
 	// As a hint, the most used class nowadays is IN (Internet).
 	Class DNSClass
+	// HttpClient is a http.Client used to connect to DoH server
+	HTTPClient *http.Client
 }
 
 // lookup encodes a DNS query, sends it over HTTPS then parses the response.
@@ -15,7 +19,7 @@ type Resolver struct {
 // parsing the response headers.
 func (r *Resolver) lookup(fqdn string, t DNSType, c DNSClass) ([]answer, error) {
 	q := encodeQuery(fqdn, t, c)
-	res, err := exchangeHTTPS(q, r.Host)
+	res, err := r.exchangeHTTPS(q)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Exported HTTPClient allowing using special HTTP methods (eg custom proxy/tls) to connect to DoH servers