### PR TITLE
Check for empty of corrupted response message.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -1,0 +1,6 @@
+package doh
+
+const (
+	// DNSMsgHeaderLen is the length of a DNS message header.
+	DNSMsgHeaderLen = 12
+)

--- a/errors.go
+++ b/errors.go
@@ -53,4 +53,4 @@ var ErrTruncated = errors.New("truncated messages aren't supported")
 
 // ErrCorrupted means that the message sent back by the server is either empty,
 // incomplete, or corrupted.
-var ErrCorrupted = errors.New("the message the server sent is empty, incomplete, or corrupted message")
+var ErrCorrupted = errors.New("the message the server sent is empty, incomplete, or corrupted")

--- a/errors.go
+++ b/errors.go
@@ -50,3 +50,7 @@ var ErrNotStandardQuery = errors.New("only standard queries are supported")
 // ErrTruncated means that the message is truncated, which isn't currently
 // supported.
 var ErrTruncated = errors.New("truncated messages aren't supported")
+
+// ErrCorrupted means that the message sent back by the server is either empty,
+// incomplete, or corrupted.
+var ErrCorrupted = errors.New("the message the server sent is empty, incomplete, or corrupted message")

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/babolivier/go-doh-client
+
+go 1.15

--- a/response.go
+++ b/response.go
@@ -95,7 +95,7 @@ func parseResponse(res []byte) ([]answer, error) {
 			|                     QCLASS                    |
 			+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
 		*/
-		if len(buf) < 0 {
+		if len(buf) == 0 {
 			return nil, ErrCorrupted
 		}
 		_, offset := p.parseName(buf)
@@ -138,7 +138,7 @@ func parseResponse(res []byte) ([]answer, error) {
 			+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
 		*/
 
-		if len(buf) < 0 {
+		if len(buf) == 0 {
 			return nil, ErrCorrupted
 		}
 		name, offset := p.parseName(buf)
@@ -150,9 +150,6 @@ func parseResponse(res []byte) ([]answer, error) {
 
 		// Set buffer value for next occurrence.
 		buf = buf[offset+10+int(rdlength):]
-		if len(buf) < 0 {
-			return nil, ErrCorrupted
-		}
 
 		// Parse the answer.
 		parsed := p.parse(t, class, rdata)

--- a/response.go
+++ b/response.go
@@ -22,6 +22,10 @@ func parseResponse(res []byte) ([]answer, error) {
 	p := new(parser)
 	p.res = res
 
+	if len(res) < DNSMsgHeaderLen {
+		return nil, ErrCorrupted
+	}
+
 	/*
 		DNS HEADER
 
@@ -72,7 +76,7 @@ func parseResponse(res []byte) ([]answer, error) {
 	ancount := binary.BigEndian.Uint16(res[6:8])
 
 	// Get to the very first byte after decoding headers.
-	buf := res[12:]
+	buf := res[DNSMsgHeaderLen:]
 	var i uint16
 	for i = 0; i < qdcount; i++ {
 		/*
@@ -91,6 +95,9 @@ func parseResponse(res []byte) ([]answer, error) {
 			|                     QCLASS                    |
 			+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
 		*/
+		if len(buf) < 0 {
+			return nil, ErrCorrupted
+		}
 		_, offset := p.parseName(buf)
 		buf = buf[offset+4:]
 	}
@@ -131,6 +138,9 @@ func parseResponse(res []byte) ([]answer, error) {
 			+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
 		*/
 
+		if len(buf) < 0 {
+			return nil, ErrCorrupted
+		}
 		name, offset := p.parseName(buf)
 		t := DNSType(binary.BigEndian.Uint16(buf[offset : offset+2]))
 		class := DNSClass(binary.BigEndian.Uint16(buf[offset+2 : offset+4]))
@@ -140,6 +150,9 @@ func parseResponse(res []byte) ([]answer, error) {
 
 		// Set buffer value for next occurrence.
 		buf = buf[offset+10+int(rdlength):]
+		if len(buf) < 0 {
+			return nil, ErrCorrupted
+		}
 
 		// Parse the answer.
 		parsed := p.parse(t, class, rdata)

--- a/response_test.go
+++ b/response_test.go
@@ -37,6 +37,12 @@ const notImplemented = "79SBlAABAAQAAAABB2JyZW5kYW4JYWJvbGl2aWVyA2J6aAAAAQABwAwA
 // This message contains the same payload as above, but with RCODE = 5 (refused).
 const refused = "nHWBlQABAAQAAAABB2JyZW5kYW4JYWJvbGl2aWVyA2J6aAAAAQABwAwABQABAAAOEAAHBGJsb2fADMAzAAUAAQAADhAAGwRibG9nEGJyZW5kYW5hYm9saXZpZXIDY29tAMBGAAUAAQABUYAACQZhcmFnb2fAS8BtAAEAAQAABwgABDMmL78AACkFrAAAAAAAAA"
 
+// This message contains an empty payload.
+const empty = ""
+
+// This messages contains a message header, but no corresponding resource records.
+const noRecords = "V8yBkAABAAEAAAAA"
+
 func TestValidHeaders(t *testing.T) {
 	res, err := base64.RawStdEncoding.DecodeString(validResponse)
 	if err != nil {
@@ -166,6 +172,22 @@ func TestRefused(t *testing.T) {
 	}
 
 	if _, err = parseResponse(res); err == nil || err != ErrRefused {
+		t.Fail()
+	}
+}
+
+func TestEmpty(t *testing.T) {
+	if _, err := parseResponse([]byte(empty)); err == nil || err != ErrCorrupted {
+		t.Fail()
+	}
+}
+
+func TestCorrupted(t *testing.T) {
+	res, err := base64.RawStdEncoding.DecodeString(noRecords)
+	if err != nil {
+		t.FailNow()
+	}
+	if _, err := parseResponse(res); err == nil || err != ErrCorrupted {
 		t.Fail()
 	}
 }


### PR DESCRIPTION
Return ErrCorrupt if the length of the the query response message is
empty or truncated.